### PR TITLE
修复初始信息

### DIFF
--- a/bus.py
+++ b/bus.py
@@ -82,14 +82,14 @@ def get_time_diff(t1, t2):
     diff = datetime.strptime(t2, TIME) - datetime.strptime(t1, TIME)
     return diff.seconds
 
-def process_time(arrives, departs):
+def process_time(arrives, departs, max_stop):
     times = [[] for _ in range(0, max_stop)]
     for i in range(0, max_stop-1):
         for arrive_next, depart in zip(arrives[i+1], departs[i]):
             times[i].append(get_time_diff(depart, arrive_next))
     return times
 
-def stay_time(arrives, departs):
+def stay_time(arrives, departs, max_stop):
     stimes = [[] for _ in range(0, max_stop)]
     for i in range(0, max_stop):
         for arrive, depart in zip(arrives[i], departs[i]):
@@ -102,8 +102,8 @@ if __name__ == '__main__':
         lines = f.readlines()
     max_stop = 5
     arrives, departs = extract_time(lines, max_stop)
-    times = process_time(arrives,departs)
-    stimes = stay_time(arrives,departs)
+    times = process_time(arrives,departs, max_stop)
+    stimes = stay_time(arrives,departs, max_stop)
     print "arrive times"
     for i in range(1, max_stop + 1):
         print "terminal %d" % i

--- a/bus.py
+++ b/bus.py
@@ -3,12 +3,10 @@
 import copy
 from datetime import datetime
 
-def extract_time(lines, max_stop):    
+def status_expansion(lines, max_stop):
     expanded_list = []
     cur_expanded = [[] for _ in range(0, max_stop)]
     prev_time = None
-    arrives = [[] for i in range(0, max_stop)]
-    departs = [[] for i in range(0, max_stop)]
     for line in lines:
         line = line.strip()
         if not line:
@@ -17,15 +15,7 @@ def extract_time(lines, max_stop):
         stop = int(stop) - 1
         if prev_time is None:
             prev_time = cur_time
-            initial_time=cur_time
 
-        if cur_time == initial_time:
-            for _ in range(0, int(nums)):
-                if int(arrived) == 1:
-                    arrives[stop].append(cur_time) 
-                else:
-                    if stop-1 >= 0:
-                        departs[stop-1].append(cur_time)
         if prev_time != cur_time:
             expanded_list.append((prev_time, cur_expanded))
             cur_expanded = [[] for i in range(0, max_stop)]
@@ -35,8 +25,29 @@ def extract_time(lines, max_stop):
 
     if prev_time:
         expanded_list.append((cur_time, cur_expanded))
+    
+    return expanded_list
 
-    prev = [None for i in range(0, max_stop)]
+def compute_augments(time, init_bus_status, max_stop):
+    # 所有未到站车，让他们出发，方便计算路段时间
+    augment_depart = [[] for i in range(0,max_stop)]
+    # 所有到站车，让他们抵达，方便计算停留时间
+    augment_arrival = [[] for i in range(0,max_stop)]
+    # 处理第一波车
+    for i in range(1, max_stop):
+        for status in init_bus_status[i]:
+            if status == 0:
+                augment_depart[i-1].append(time)
+            else:
+                augment_arrival[i].append(time)
+    return (augment_arrival, augment_depart)
+
+
+def extract_time_expanded(expanded_list, max_stop):    
+    arrives = [[] for i in range(0, max_stop)]
+    departs = [[] for i in range(0, max_stop)]
+
+    prev = [[] for i in range(0, max_stop)]
     for time, expanded in expanded_list:
         expanded_copy = copy.deepcopy(expanded)
         for i in range(0, max_stop):
@@ -77,6 +88,11 @@ def extract_time(lines, max_stop):
 
     return arrives, departs
 
+# This is for testing...(need to change tests)
+def extract_time(lines, max_stop):
+    expanded = status_expansion(lines, max_stop)
+    return extract_time_expanded(expanded, max_stop)
+
 def get_time_diff(t1, t2):
     TIME = '%Y-%m-%d %H:%M:%S'
     diff = datetime.strptime(t2, TIME) - datetime.strptime(t1, TIME)
@@ -96,30 +112,33 @@ def stay_time(arrives, departs, max_stop):
             stimes[i].append(get_time_diff(arrive, depart))
     return stimes
 
+def extract_time_all(lines, max_stop):
+    expanded = status_expansion(lines, max_stop)
+    time, init_bus_status = expanded[0]
+    arrive_aug, depart_aug = compute_augments(time, init_bus_status, max_stop)
+    arrives, departs = extract_time_expanded(expanded, max_stop)
+    arrives_copy = copy.deepcopy(arrives)
+    departs_copy = copy.deepcopy(departs)
+    # 计算路段时间时，添加初始离站信息
+    for i in range(0, max_stop):
+        if depart_aug[i]:
+            depart_aug[i].extend(departs_copy[i])
+            departs_copy[i] = depart_aug[i]
+    ptime = process_time(arrives, departs_copy, max_stop)
+
+    for i in range(0, max_stop):
+        if arrive_aug[i]:
+            arrive_aug[i].extend(arrives_copy[i])
+            arrives_copy[i] = arrive_aug[i] 
+    stime = stay_time(arrives_copy, departs, max_stop)
+    return (ptime, stime)
+
+
 if __name__ == '__main__':
     lines = []
     with open('buslian2.txt') as f:
         lines = f.readlines()
     max_stop = 5
-    arrives, departs = extract_time(lines, max_stop)
-    times = process_time(arrives,departs, max_stop)
-    stimes = stay_time(arrives,departs, max_stop)
-    print "arrive times"
-    for i in range(1, max_stop + 1):
-        print "terminal %d" % i
-        print arrives[i]
-
-    print "depart times"
-    for i in range(1, max_stop + 1):
-        print "terminal %d" % i
-        print departs[i]
-
-    print "process times"
-    for i in range(1, max_stop + 1):
-        print "terminal %d" % i
-        print times[i]
-
-    print "stay times"
-    for i in range(1, max_stop + 1):
-        print "terminal %d" % i
-        print stimes[i]
+    ptime, stime = extract_time_all(lines, max_stop)
+    print ptime
+    print stime

--- a/bus_test.py
+++ b/bus_test.py
@@ -120,7 +120,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(departs, [['2017-11-03 15:53:17','2017-11-03 15:53:32'], [], []])
 #有两辆车的时候 程序运行只有一个depart时间
 
-    def test_bug(self):
+    def test_multistart(self):
         lines = ['801,1,1,0,1,2017-11-03 15:52:32',
                  '801,1,1,0,3,2017-11-03 15:52:32',
                  '801,0,1,0,2,2017-11-03 15:52:47',
@@ -132,11 +132,9 @@ class Tests(unittest.TestCase):
                  '801,1,1,0,3,2017-11-03 15:53:17',
                  '801,1,1,0,5,2017-11-03 15:53:17']
 
-        arrives, departs = bus.extract_time(lines, 6)
-        print arrives
-        print departs
-        print bus.process_time(arrives,departs,6)
-        print bus.stay_time(arrives,departs,6)
+        ptime, stime = bus.extract_time_all(lines, 5)
+        self.assertEqual(ptime, [[13],[7],[13],[7],[]])
+        self.assertEqual(stime, [[],[10],[15],[10],[]])
 
 
 if __name__ == '__main__':

--- a/bus_test.py
+++ b/bus_test.py
@@ -119,5 +119,25 @@ class Tests(unittest.TestCase):
         self.assertEqual(arrives, [['2017-11-03 15:52:47', '2017-11-03 15:53:02'], [], []])
         self.assertEqual(departs, [['2017-11-03 15:53:17','2017-11-03 15:53:32'], [], []])
 #有两辆车的时候 程序运行只有一个depart时间
+
+    def test_bug(self):
+        lines = ['801,1,1,0,1,2017-11-03 15:52:32',
+                 '801,1,1,0,3,2017-11-03 15:52:32',
+                 '801,0,1,0,2,2017-11-03 15:52:47',
+                 '801,0,1,0,4,2017-11-03 15:52:47',
+                 '801,1,1,0,2,2017-11-03 15:53:00',
+                 '801,1,1,0,4,2017-11-03 15:53:00',
+                 '801,0,1,0,3,2017-11-03 15:53:10',
+                 '801,0,1,0,5,2017-11-03 15:53:10',
+                 '801,1,1,0,3,2017-11-03 15:53:17',
+                 '801,1,1,0,5,2017-11-03 15:53:17']
+
+        arrives, departs = bus.extract_time(lines, 6)
+        print arrives
+        print departs
+        print bus.process_time(arrives,departs,6)
+        print bus.stay_time(arrives,departs,6)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
再次尝试修复初始信息

原先考虑到了初始车辆欠缺出站/到站时间这个问题，采取了添加第0组离站和到站信息。只是我们都是统一添加的，相当于没有处理初始(第0组)车辆。

计算不同的时间(停留或是路段)应该做不同的初始处理。停留需要额外的初始到站信息，路段需要额外的出站信息。

测试都要重写